### PR TITLE
Save and read date as UNIX epoch

### DIFF
--- a/lib/botRepository.js
+++ b/lib/botRepository.js
@@ -30,11 +30,12 @@ class BotRepository {
   }
 
   getLastPolledDate() {
-    return Rx.Observable.fromPromise(this.redis.get(LAST_POLLED_DATE));
+    return Rx.Observable.fromPromise(this.redis.get(LAST_POLLED_DATE))
+      .select(date => new Date(parseInt(date, 10)));
   }
 
   setLastPolledDate() {
-    this.redis.set(LAST_POLLED_DATE, new Date());
+    this.redis.set(LAST_POLLED_DATE, (new Date()).getTime());
   }
 
 }

--- a/lib/botRepository.js
+++ b/lib/botRepository.js
@@ -31,11 +31,11 @@ class BotRepository {
 
   getLastPolledDate() {
     return Rx.Observable.fromPromise(this.redis.get(LAST_POLLED_DATE))
-      .select(date => new Date(parseInt(date, 10)));
+      .select(date => new Date(date));
   }
 
   setLastPolledDate() {
-    this.redis.set(LAST_POLLED_DATE, (new Date()).getTime());
+    this.redis.set(LAST_POLLED_DATE, (new Date()).toJSON());
   }
 
 }


### PR DESCRIPTION
Redis saves every object as `String`, therefore all dates were saved with `Date.prototype.toString`, hence it sucks, so this PR happened.

![monkey](http://i.giphy.com/BBkKEBJkmFbTG.gif)
