### PR TITLE
Implement start and stop commands

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -68,12 +68,16 @@ module.exports = function() {
 
   let sioBot = new SioBot({
     start: (event) => {
-      return sioBot.sendText(event.chat.id, 'OK AHAHAHAHLOL')
-        .subscribe(observer);
+      return sioBot.addChat(event)
+        .map(() => {
+          return sioBot.sendText(event.chat.id, 'OK AHAHAHAHLOL')
+        }).subscribe(observer);
     },
     stop: (event) => {
-      return sioBot.sendText(event.chat.id, 'LOL NO.')
-        .subscribe(observer);
+      return sioBot.delChat(event)
+        .map(() => {
+          return sioBot.sendText(event.chat.id, 'UFFA CHE PYZZA PERO\' VABBE\' CIAO');
+        }).subscribe(observer);        
     },
     oggy: (event) => {
       return sioFb.getLastStrip()

--- a/lib/app.js
+++ b/lib/app.js
@@ -70,13 +70,13 @@ module.exports = function() {
     start: (event) => {
       return sioBot.addChat(event)
         .doOnNext(() => {
-          return sioBot.sendText(event.chat.id, 'OK AHAHAHAHLOL')
+          sioBot.sendText(event.chat.id, 'OK AHAHAHAHLOL')
         }).subscribe(observer);
     },
     stop: (event) => {
       return sioBot.delChat(event)
         .doOnNext(() => {
-          return sioBot.sendText(event.chat.id, 'UFFA CHE PYZZA PERO\' VABBE\' CIAO');
+          sioBot.sendText(event.chat.id, 'UFFA CHE PYZZA PERÒ VABBÈ CIAO');
         }).subscribe(observer);        
     },
     oggy: (event) => {

--- a/lib/app.js
+++ b/lib/app.js
@@ -69,13 +69,13 @@ module.exports = function() {
   let sioBot = new SioBot({
     start: (event) => {
       return sioBot.addChat(event)
-        .map(() => {
+        .doOnNext(() => {
           return sioBot.sendText(event.chat.id, 'OK AHAHAHAHLOL')
         }).subscribe(observer);
     },
     stop: (event) => {
       return sioBot.delChat(event)
-        .map(() => {
+        .doOnNext(() => {
           return sioBot.sendText(event.chat.id, 'UFFA CHE PYZZA PERO\' VABBE\' CIAO');
         }).subscribe(observer);        
     },

--- a/lib/botRepository.js
+++ b/lib/botRepository.js
@@ -17,11 +17,11 @@ class BotRepository {
   }
 
   addChat(chatId) {
-    this.redis.sadd(CHATS_SET_KEY, chatId);
+    return Rx.Observable.fromPromise(this.redis.sadd(CHATS_SET_KEY, chatId));
   }
 
   delChat(chatId) {
-    this.redis.srem(CHATS_SET_KEY, chatId);
+    return Rx.Observable.fromPromise(this.redis.srem(CHATS_SET_KEY, chatId));
   }
 
   getAllChats() {

--- a/lib/sioBot.js
+++ b/lib/sioBot.js
@@ -88,11 +88,11 @@ class SioBot {
   };
 
   addChat(event) {
-    this.repository.addChat(event.chat.id);
+    return this.repository.addChat(event.chat.id);
   }
 
   delChat(event) {
-    this.repository.delChat(event.chat.id);
+    return this.repository.delChat(event.chat.id);
   }
 
   getAllChats() {


### PR DESCRIPTION
`/start`explicitly adds the current chat to the set of handled chats, while `/stop` removes it. This way the bot can remain in a group without having to automatically send images.
